### PR TITLE
Option to mention someone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,3 +62,14 @@ You can also filter some messages only
     
     logger.info('info message')  # Not posted to slack
     logger.info('info message to slack', extra={'notify_slack': True})  # Posted to slack
+
+Mentioning someone
+''''''''''''''''''
+
+Use ``mention`` option to send message with mentioning someone:
+
+.. code-block:: python
+
+   sh = SlackHandler('YOUR_WEB_HOOK_URL', mention='U012ABC34')
+
+You can find a member ID (e.g., ``U012ABC34``) from user's profile view.


### PR DESCRIPTION
Thank you for making a useful library!

This patch adds a new option named `mention` which purposes to send messages with mentioning someone.  If the option is omitted it behaves as like it has done.

An example code follows:

```python
import logging
from slack_logger import SlackHandler, SlackFormatter

sh = SlackHandler(
    'YOUR_WEB_HOOK_URL',
    username='python-slack-logger',
    icon_emoji=':thinking_face:',
    mention='U012ABC34'
)
sh.setFormatter(SlackFormatter())
logging.basicConfig(handlers=[sh])
logging.warning("Trying SlackHandler's mention= option...")
```

A message the above code sent looks like:

![screen shot 2017-12-14 at 1 51 55 am](https://user-images.githubusercontent.com/12431/33951534-8f7ad944-e072-11e7-9f8d-d5253b435973.png)

Postscript: Although its setup.py indicates the project is licensed under MIT, it would be more clear if the repository contains an explicit LICENSE file as well. GitHub also can recognize the LICENSE file so that [it shows project's license on the overview bar][1].

[1]: https://github.com/blog/2252-license-now-displayed-on-repository-overview